### PR TITLE
Spelling Correction and Improve README readability while editing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,22 @@
 # Elden Ring Gamepad UI
-This mod patches the internal texture layout files for Elden Ring to use Dualsense or Dualshock UI for buttons prompts and gamepad (settings screen).
+
+This mod patches the internal texture layout files for Elden Ring to use
+Dualsense or Dualshock UI for buttons prompts and gamepad (settings screen).
 
 ## Tools
 
-Unpacking game files: [ER.BDT.Tool](https://github.com/Ekey/ER.BDT.Tool/) by Ekey
+Unpacking game files:
+[ER.BDT.Tool](https://github.com/Ekey/ER.BDT.Tool/) by Ekey
 
-Unpacking/repacking internal files: [Yabber](https://github.com/JKAnderson/Yabber/) by JKAnderson
+Unpacking/repacking internal files:
+[Yabber](https://github.com/JKAnderson/Yabber/) by JKAnderson
 
-Visual verification of game texture: Paint.net and .dds mod for Paint.net
+Visual verification of game texture:
+Paint.net and .dds mod for Paint.net
 
-Editing layout files: Sublime Text because VSCode on my computer died the other day
+Editing layout files:
+Sublime Text because VSCode on my computer died the other day
 
-Special thanks to: Sekiro Resurection Modding Wiki for making the only good resource on modding modern FromSoftware games
+Special thanks to:
+Sekiro Resurrection Modding Wiki for making the only good resource on modding
+modern FromSoftware games

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@ This mod patches the internal texture layout files for Elden Ring to use Dualsen
 
 Tools used:
 
-Unpacking game files: ER.BDT.Tool by Ekey
-Unpacking/repacking internal files: Yabber by JKAnderson
+Unpacking game files: [ER.BDT.Tool](https://github.com/Ekey/ER.BDT.Tool/) by Ekey
+Unpacking/repacking internal files: [Yabber](https://github.com/JKAnderson/Yabber/) by JKAnderson
 Visual verification of game texture: Paint.net and .dds mod for Paint.net
 Editing layout files: Sublime Text because VSCode on my computer died the other day
 Special thanks to: Sekiro Resurection Modding Wiki for making the only good resource on modding modern FromSoftware games

--- a/README.md
+++ b/README.md
@@ -1,9 +1,14 @@
+# Elden Ring Gamepad UI
 This mod patches the internal texture layout files for Elden Ring to use Dualsense or Dualshock UI for buttons prompts and gamepad (settings screen).
 
-Tools used:
+## Tools
 
 Unpacking game files: [ER.BDT.Tool](https://github.com/Ekey/ER.BDT.Tool/) by Ekey
+
 Unpacking/repacking internal files: [Yabber](https://github.com/JKAnderson/Yabber/) by JKAnderson
+
 Visual verification of game texture: Paint.net and .dds mod for Paint.net
+
 Editing layout files: Sublime Text because VSCode on my computer died the other day
+
 Special thanks to: Sekiro Resurection Modding Wiki for making the only good resource on modding modern FromSoftware games


### PR DESCRIPTION
- Corrected a 'Resurection' to 'Resurrection' in README.md

The following changes to README.md _do not_ affect the way that the text is displayed by a markdown renderer, only how it appears in a text editor.

- Reformat the text such that each line has a maximum of 80 characters to improve readability within a text editor.
- For each item under 'Tools', I replaced the 'space' after the colon with a 'newline' character in order to make editing each entry slightly easier, and to improve readability within a text editor.

Once again, the two changes above _do not_ affect the way that the text is displayed by a markdown renderer, such as the ones on GitHub and GitLab.